### PR TITLE
elimina paquete hashlib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 facturacion_electronica
-hashlib
 suds
 signxml
 ast


### PR DESCRIPTION
Integrado desde Python 2.5.
Necesario para odoo.sh ya que usa Python 2.7 (build falla)