### PR TITLE
agrega paquete pybase64 y remueve hashlib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 facturacion_electronica
-hashlib
+pybase64
 suds
 signxml
 ast


### PR DESCRIPTION
Anteriormente aparecía como requerimiento "base64", la solución no es eliminarlo si no que usar el paquete correcto llamado "pybase64".
El paquete "hashlib" viene integrado desde Python 2.5, como Odoo.sh usa Python 2.7 este debe ser removido o la build falla.